### PR TITLE
Fix bug: only display visible children

### DIFF
--- a/menu/menu.py
+++ b/menu/menu.py
@@ -114,9 +114,13 @@ class Menu(object):
         if curitem is not None:
             curitem.selected = True
 
+        def filter_visible_children(item):
+            item.children = [filter_visible_children(child) for child in item.children if child.visible]
+            return item
+
         # return only visible items
         visible = [
-            item
+            filter_visible_children(item)
             for item in c.items[name]
             if item.visible
         ]

--- a/menu/menu.py
+++ b/menu/menu.py
@@ -114,16 +114,15 @@ class Menu(object):
         if curitem is not None:
             curitem.selected = True
 
+        def filter_visible(items):
+            return [filter_visible_children(item) for item in items if item.visible]
+
         def filter_visible_children(item):
-            item.children = [filter_visible_children(child) for child in item.children if child.visible]
+            item.children = filter_visible(item.children)
             return item
 
         # return only visible items
-        visible = [
-            filter_visible_children(item)
-            for item in c.items[name]
-            if item.visible
-        ]
+        visible = filter_visible(c.items[name])
 
         # determine if we should apply 'selected' to parents when one of their
         # children is the 'selected' menu


### PR DESCRIPTION
Currently only top level items are filtered for visibility. This has the effect that `check` arguments in child items are ignored.
This change fixes this by filtering children items recursively.