### PR TITLE
Allow custom complex checks to be implement via a subclass

### DIFF
--- a/menu/menu.py
+++ b/menu/menu.py
@@ -145,8 +145,7 @@ class Menu(object):
 
 class MenuItem(object):
     """
-    MenuItem represents an item in a menu, possibly one that has a sub-
-    menu (children).
+    MenuItem represents an item in a menu, possibly one that has a sub-menu (children).
     """
 
     def __init__(self, title, url, children=[], weight=1, check=None,
@@ -176,7 +175,7 @@ class MenuItem(object):
         self.visible = visible
         self.children = children
         self.weight = weight
-        self.check = check
+        self.check_func = check
         self.slug = slug
         self.exact_url = exact_url
         self.selected = False
@@ -186,15 +185,19 @@ class MenuItem(object):
         for k in kwargs:
             setattr(self, k, kwargs[k])
 
+    def check(self, request):
+        """
+        Evaluate if we should be visible for this request
+        """
+        if callable(self.check_func):
+            self.visible = self.check_func(request)
+
     def process(self, request):
         """
         process determines if this item should visible, if its selected, etc...
         """
-        # evaluate our check
-        if callable(self.check):
-            self.visible = self.check(request)
-
         # if we're not visible we return since we don't need to do anymore processing
+        self.check(request)
         if not self.visible:
             return
 

--- a/menu/tests/test_menu.py
+++ b/menu/tests/test_menu.py
@@ -17,6 +17,18 @@ from menu import Menu, MenuItem
 
 # XXX TODO: test MENU_HIDE_EMPTY
 
+
+class CustomMenuItem(MenuItem):
+    """
+    Custom MenuItem subclass with custom check logic
+    """
+    def check(self, request):
+        """
+        We should be visible unless the request path ends with "foo"
+        """
+        self.visible = not request.path.endswith("foo")
+
+
 class MenuTests(TestCase):
     """
     Tests for Menu
@@ -59,8 +71,8 @@ class MenuTests(TestCase):
             ]
 
         kids3 = (
-            MenuItem("kids3-1", "/parent3/kids3-1", children=kids3_1, slug="salty"),
-            MenuItem(kids3_2_title, "/parent3/kids3-2")
+            CustomMenuItem("kids3-1", "/parent3/kids3-1", children=kids3_1, slug="salty"),
+            CustomMenuItem(kids3_2_title, "/parent3/kids3-2")
         )
 
         Menu.items = {}
@@ -74,6 +86,18 @@ class MenuTests(TestCase):
         Menu.add_item("test", MenuItem("Parent 3", "/parent3", children=kids3))
 
         self.factory = RequestFactory()
+
+    def test_custom_menuitem(self):
+        """
+        Ensure our custom check on our custom MenuItem works
+        """
+        request = self.factory.get('/parent3/kids3-1')
+        items = Menu.process(request, 'test')
+        self.assertEqual(len(items[1].children), 2)
+
+        request = self.factory.get('/parent3/kids3-1/foo')
+        items = Menu.process(request, 'test')
+        self.assertEqual(len(items[1].children), 0)
 
     def test_thread_safety_and_checks(self):
         """


### PR DESCRIPTION
By default the check function doesn't get access to the MenuItem that is invoking it, but for certain generalizations it may be desirable to have access to attrs like `self.url` on the MenuItem.

With `check` being broken out into it's own function again this allows for someone to subclass `MenuItem` and implement complex, general logic that can be used on all of their menu items.

This is based on #40